### PR TITLE
Add load subsystem by parent option

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -146,6 +146,7 @@ void retro_set_environment(retro_environment_t cb)
 
 char g_driver_name[128];
 char g_rom_dir[MAX_PATH];
+char g_rom_parent_dir[MAX_PATH];
 char g_save_dir[MAX_PATH];
 char g_system_dir[MAX_PATH];
 char g_autofs_path[MAX_PATH];
@@ -1256,9 +1257,64 @@ bool retro_load_game(const struct retro_game_info *info)
 {
 	if (!info)
 		return false;
-
+	
 	extract_basename(g_driver_name, info->path, sizeof(g_driver_name), "");
 	extract_directory(g_rom_dir, info->path, sizeof(g_rom_dir));
+	extract_basename(g_rom_parent_dir, g_rom_dir, sizeof(g_rom_parent_dir),"");
+	char * prefix="";
+	if (bLoadSubsystemByParent == true) {
+		if(strcmp(g_rom_parent_dir, "coleco")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem cv identified from parent folder\n");
+			prefix = "cv_";
+		}
+		if(strcmp(g_rom_parent_dir, "gamegear")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem gg identified from parent folder\n");
+			prefix = "gg_";
+		}
+		if(strcmp(g_rom_parent_dir, "megadriv")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem md identified from parent folder\n");
+			prefix = "md_";
+		}
+		if(strcmp(g_rom_parent_dir, "msx")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem msx identified from parent folder\n");
+			prefix = "msx_";
+		}
+		if(strcmp(g_rom_parent_dir, "pce")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem pce identified from parent folder\n");
+			prefix = "pce_";
+		}
+		if(strcmp(g_rom_parent_dir, "sg1000")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem sg1k identified from parent folder\n");
+			prefix = "sg1k_";
+		}
+		if(strcmp(g_rom_parent_dir, "sgx")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem sgx identified from parent folder\n");
+			prefix = "sgx_";
+		}
+		if(strcmp(g_rom_parent_dir, "sms")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem sms identified from parent folder\n");
+			prefix = "sms_";
+		}
+		if(strcmp(g_rom_parent_dir, "spectrum")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem spec identified from parent folder\n");
+			prefix = "spec_";
+		}
+		if(strcmp(g_rom_parent_dir, "tg16")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem tg identified from parent folder\n");
+			prefix = "tg_";
+		}
+		if(strcmp(g_rom_parent_dir, "neocd")==0) {
+			log_cb(RETRO_LOG_INFO, "[FBNEO] subsystem neocd identified from parent folder\n");
+			prefix = "";
+			nGameType = RETRO_GAME_TYPE_NEOCD;
+			strcpy(CDEmuImage, info->path);
+			extract_basename(g_driver_name, "neocdz", sizeof(g_driver_name), prefix);
+		} else {
+			extract_basename(g_driver_name, info->path, sizeof(g_driver_name), prefix);
+		}
+	} else {
+		extract_basename(g_driver_name, info->path, sizeof(g_driver_name), "");
+	}
 
 	return retro_load_game_common();
 }

--- a/src/burner/libretro/retro_common.cpp
+++ b/src/burner/libretro/retro_common.cpp
@@ -56,6 +56,7 @@ bool is_neogeo_game = false;
 bool allow_neogeo_mode = true;
 bool bVerticalMode = false;
 bool bAllowDepth32 = false;
+bool bLoadSubsystemByParent = true;
 UINT32 nFrameskip = 1;
 INT32 g_audio_samplerate = 48000;
 UINT8 *diag_input;
@@ -228,6 +229,18 @@ static const struct retro_core_option_definition var_fbneo_neogeo_mode = {
 	"DIPSWITCH"
 };
 
+static const struct retro_core_option_definition var_fbneo_load_subsystem_from_parent = {
+	"fbneo-load-subsystem-from-parent",
+	"Load Subsystem from Parent Folder",
+	"If enabled, supported subsystems will be loaded using the parent directory name",
+	{
+		{ "disabled", NULL },
+		{ "enabled", NULL },
+		{ NULL, NULL },
+	},
+	"enabled"
+};
+
 // Replace the char c_find by the char c_replace in the destination c string
 char* str_char_replace(char* destination, char c_find, char c_replace)
 {
@@ -365,6 +378,7 @@ void set_environment()
 	vars_systems.push_back(&var_fbneo_frameskip);
 	vars_systems.push_back(&var_fbneo_cpu_speed_adjust);
 	vars_systems.push_back(&var_fbneo_hiscores);
+	vars_systems.push_back(&var_fbneo_load_subsystem_from_parent);
 	if (nGameType != RETRO_GAME_TYPE_NEOCD)
 		vars_systems.push_back(&var_fbneo_samplerate);
 	vars_systems.push_back(&var_fbneo_sample_interpolation);
@@ -649,6 +663,15 @@ void check_variables(void)
 			bVerticalMode = true;
 		else
 			bVerticalMode = false;
+	}
+
+	var.key = var_fbneo_load_subsystem_from_parent.key;
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+	{
+		if (strcmp(var.value, "enabled") == 0)
+			bLoadSubsystemByParent = true;
+		else
+			bLoadSubsystemByParent = false;
 	}
 
 	var.key = var_fbneo_frameskip.key;

--- a/src/burner/libretro/retro_common.h
+++ b/src/burner/libretro/retro_common.h
@@ -103,6 +103,7 @@ extern bool is_neogeo_game;
 extern bool allow_neogeo_mode;
 extern bool core_aspect_par;
 extern bool bVerticalMode;
+extern bool bLoadSubsystemByParent;
 extern bool bAllowDepth32;
 extern UINT32 nFrameskip;
 extern UINT8 NeoSystem;


### PR DESCRIPTION
Load subsystem based on parent directory name.  The parent folder names I used were based on naming in the common romset:
```
coleco
gamegear
megadriv
neocd
msx
pce
sg1000
spectrum
sgx
sms
tg16
```
This would close #66 