### PR TITLE
fix build libnx

### DIFF
--- a/src/burner/libretro/Makefile
+++ b/src/burner/libretro/Makefile
@@ -283,6 +283,7 @@ else ifeq ($(platform), switch)
 # Nintendo Switch (libnx)
 else ifeq ($(platform), libnx)
 	include $(DEVKITPRO)/libnx/switch_rules
+	AR="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-ar$(BINARY_EXT)"
 	EXT=a
 	TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
 	DEFINES := -DSWITCH=1 -U__linux__ -U__linux -DRARCH_INTERNAL


### PR DESCRIPTION
fix build libnx get no such file aarch64-none-elf-gcc-ar