### PR TITLE
fix(retro_input): add missing inputs for Williams games

### DIFF
--- a/src/burner/libretro/retro_input.cpp
+++ b/src/burner/libretro/retro_input.cpp
@@ -1597,14 +1597,11 @@ static INT32 GameInpSpecialOne(struct GameInp* pgi, INT32 nPlayer, char* szb, ch
 		(parentrom && strcmp(parentrom, "sinistar") == 0) ||
 		(drvname && strcmp(drvname, "sinistar") == 0)
 	) {
-		if (strcmp("Advance", description) == 0) {
-			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_L, description);
-		}
 		if (strcmp("Auto Up / Manual Down", description) == 0) {
-			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_L2, description);
+			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_L3, description);
 		}
 		if (strcmp("High Score Reset", description) == 0) {
-			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_R, description);
+			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_R3, description);
 		}
 	}
 

--- a/src/burner/libretro/retro_input.cpp
+++ b/src/burner/libretro/retro_input.cpp
@@ -1581,6 +1581,33 @@ static INT32 GameInpSpecialOne(struct GameInp* pgi, INT32 nPlayer, char* szb, ch
 		}
 	}
 
+	// Defender
+	// Stargate
+	// Robotron
+	// Joust
+	// Sinistar
+	if ((parentrom && strcmp(parent, "defender") == 0) ||
+	  (drvname && strcmp(drvname, "defender") == 0) ||
+		(parentrom && strcmp(parentrom, "stargate") == 0) ||
+		(drvname && strpcmp(drvname, "stargate") == 0) ||
+		(parentrom && strcmp(parentrom, "robotron") == 0) ||
+		(drvname && strcmp(drvname, "robotron") == 0) ||
+		(parentrom && strcmp(parentrom, "joust") == 0) ||
+		(drvname && strcmp(drvname, "joust") == 0) ||
+		(parentrom && strcmp(parentrom, "sinistar") == 0) ||
+		(drvname && strcmp(drvname, "sinistar") == 0)
+	) {
+		if (strcmp("Advance", description) == 0) {
+			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_L, description);
+		}
+		if (strcmp("Auto Up / Manual Down", description) == 0) {
+			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_L2, description);
+		}
+		if (strcmp("High Score Reset", description) == 0) {
+			GameInpDigital2RetroInpKey(pgi, 0, RETRO_DEVICE_ID_JOYPAD_R, description);
+		}
+	}
+
 	// Ms. Pac-Man/Galaga - 20th Anniversary Class of 1981 Reunion
 	// Pac-Man - 25th Anniversary Edition
 	if ((parentrom && strcmp(parentrom, "20pacgal") == 0) ||

--- a/src/burner/libretro/retro_input.cpp
+++ b/src/burner/libretro/retro_input.cpp
@@ -1586,10 +1586,10 @@ static INT32 GameInpSpecialOne(struct GameInp* pgi, INT32 nPlayer, char* szb, ch
 	// Robotron
 	// Joust
 	// Sinistar
-	if ((parentrom && strcmp(parent, "defender") == 0) ||
+	if ((parentrom && strcmp(parentrom, "defender") == 0) ||
 	  (drvname && strcmp(drvname, "defender") == 0) ||
 		(parentrom && strcmp(parentrom, "stargate") == 0) ||
-		(drvname && strpcmp(drvname, "stargate") == 0) ||
+		(drvname && strcmp(drvname, "stargate") == 0) ||
 		(parentrom && strcmp(parentrom, "robotron") == 0) ||
 		(drvname && strcmp(drvname, "robotron") == 0) ||
 		(parentrom && strcmp(parentrom, "joust") == 0) ||


### PR DESCRIPTION
This PR adds several button mappings for Defender, Stargate, Robotron, Joust, and Sinistar.

These games did not have physical DIP switches to adjust their settings. Their settings were controlled by software via a settings menu, and the buttons to navigate the settings menu were inside the arcade cabinet. Right now, these buttons cannot be bound using RetroArch. As a result, the settings for these games cannot be changed.

The settings menus were navigated by using a combination of the Advance, Auto Up / Manual Down, and High Score Reset buttons. I have added bindings for these buttons in *retro_input.cpp*.