### PR TITLE
Fix undefined reference to dlsym

### DIFF
--- a/src/burner/libretro/Makefile
+++ b/src/burner/libretro/Makefile
@@ -73,7 +73,7 @@ ifneq (,$(findstring unix,$(platform)))
 	fpic := -fPIC
 	SHARED := -shared -Wl,-no-undefined -Wl,--version-script=$(VERSION_SCRIPT)
 	ENDIANNESS_DEFINES := -DLSB_FIRST
-	LDFLAGS += -lpthread
+	LDFLAGS += -lpthread -ldl
 
 	# Raspberry Pi
 	ifneq (,$(findstring rpi1,$(platform)))


### PR DESCRIPTION
Fixes issue on webOS:

```
getauxval.c:(.text+0x20c): undefined reference to `dlsym'
```