### PR TITLE
Make "RETRO_ERROR_MESSAGES_12" be used correctly

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -1230,7 +1230,7 @@ static bool open_archive()
 		{
 			static char prev[2048];
 			strcpy(prev, text_missing_files);
-			sprintf(text_missing_files, "%s\nAnd %d more...", prev, (num_missing - 18));
+			sprintf(text_missing_files, RETRO_ERROR_MESSAGES_12, prev, (num_missing - 18));
 		}
 
 		BurnExtLoadRom = archive_load_rom;

--- a/src/burner/libretro/retro_string.h
+++ b/src/burner/libretro/retro_string.h
@@ -169,7 +169,7 @@ void set_multi_language_strings();
 #define RETRO_ERROR_MESSAGES_09				pSelLangStr[138]
 #define RETRO_ERROR_MESSAGES_10				pSelLangStr[139]
 #define RETRO_ERROR_MESSAGES_11				pSelLangStr[140]
-#define RETRO_ERROR_MESSAGES_12				pSelLangStr[141]
+#define RETRO_ERROR_MESSAGES_12				pSelLangStr[159]
 
 
 #endif


### PR DESCRIPTION
<img width="1306" height="768" alt="01" src="https://github.com/user-attachments/assets/15f4fa8e-ba5c-4ed0-a610-a2af0d69f851" />
<img width="1306" height="768" alt="02" src="https://github.com/user-attachments/assets/6d74b93f-5369-4737-8b4f-bc3392aec18f" />