### PR TITLE
Add support for 16KB pages on Android.

### DIFF
--- a/src/burner/libretro/jni/Android.mk
+++ b/src/burner/libretro/jni/Android.mk
@@ -41,10 +41,11 @@ LOCAL_SRC_FILES    := $(SOURCES_C) $(SOURCES_S) $(SOURCES_CXX)
 LOCAL_C_INCLUDES   := $(INCLUDE_DIRS)
 LOCAL_CFLAGS       := $(CFLAGS) $(COMMON_FLAGS)
 LOCAL_CPPFLAGS     := $(CXXFLAGS) $(COMMON_FLAGS)
-LOCAL_LDFLAGS      := -Wl,-version-script=$(MAIN_FBNEO_DIR)/burner/libretro/link.T
+LOCAL_LDFLAGS      := -Wl,-version-script=$(MAIN_FBNEO_DIR)/burner/libretro/link.T,-z,max-page-size=16384
 LOCAL_LDLIBS       := $(LDFLAGS)
 LOCAL_CPP_FEATURES := exceptions rtti
 LOCAL_DISABLE_FORMAT_STRING_CHECKS := true
+LOCAL_SHORT_COMMANDS := true
 LOCAL_ARM_MODE := arm
 
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)


### PR DESCRIPTION
Since last year Google is requiring every application on Google Play to support 16KB pages: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

It's a tiny build script change, I've tested it locally and it's working fine.

We did a test pilot with fceumm (https://github.com/libretro/libretro-fceumm/pull/644) and now I'm creating all the PRs for the other cores.